### PR TITLE
[HAX] Allow per-target dtbTool

### DIFF
--- a/core/generate_extra_images.mk
+++ b/core/generate_extra_images.mk
@@ -89,18 +89,28 @@ ifeq ($(strip $(BUILD_TINY_ANDROID)),true)
 include device/qcom/common/dtbtool/Android.mk
 endif
 
-DTBTOOL := $(HOST_OUT_EXECUTABLES)/dtbTool$(HOST_EXECUTABLE_SUFFIX)
+ifeq ($(strip $(TARGET_CUSTOM_DTBTOOL)),)
+DTBTOOL_NAME := dtbToolCM
+else
+DTBTOOL_NAME := $(TARGET_CUSTOM_DTBTOOL)
+endif
+
+DTBTOOL := $(HOST_OUT_EXECUTABLES)/$(DTBTOOL_NAME)$(HOST_EXECUTABLE_SUFFIX)
 
 INSTALLED_DTIMAGE_TARGET := $(PRODUCT_OUT)/dt.img
 
+possible_dtb_dirs = $(KERNEL_OUT)/arch/$(TARGET_KERNEL_ARCH)/boot/dts/ $(KERNEL_OUT)/arch/arm/boot/
+dtb_dir = $(firstword $(wildcard $(possible_dtb_dirs)))
+
 define build-dtimage-target
     $(call pretty,"Target dt image: $(INSTALLED_DTIMAGE_TARGET)")
-    $(hide) $(DTBTOOL) -o $@ -s $(BOARD_KERNEL_PAGESIZE) -p $(KERNEL_OUT)/scripts/dtc/ $(KERNEL_OUT)/arch/arm/boot/
+    $(hide) $(DTBTOOL) $(BOARD_DTBTOOL_ARGS) -o $@ -s $(BOARD_KERNEL_PAGESIZE) -p $(KERNEL_OUT)/scripts/dtc/ $(dtb_dir)
     $(hide) chmod a+r $@
 endef
 
 $(INSTALLED_DTIMAGE_TARGET): $(DTBTOOL) $(INSTALLED_KERNEL_TARGET)
 	$(build-dtimage-target)
+	@echo -e ${CL_CYN}"Made DT image: $@"${CL_RST}
 
 ALL_DEFAULT_INSTALLED_MODULES += $(INSTALLED_DTIMAGE_TARGET)
 ALL_MODULES.$(LOCAL_MODULE).INSTALLED += $(INSTALLED_DTIMAGE_TARGET)


### PR DESCRIPTION
Temp- This will fix the no dtbtool error.. more changes coming
- Revert this when fixed

Change-Id: I97ecb0448ae7bd5859454be290c5dde6248b2859

build: Default to dtbToolCM
- The default dtbTool isn't the correct module name for the module that
  actually lives in device/qcom/common/dtbtool

Change-Id: I80b427e3652b99742573bc4d2829e51645a8822b

generate_extra_images: Look for 3.10 dtbs

The dtbs have changed location between 3.4 and 3.10. Look for the
new location first and fallback to the 3.4 location if they're
missing.

Change-Id: I7aada8dbcf01ea6f62b3235b452c9329cd69e5e8

build: Generalize kernel DTB path

Use $TARGET_KERNEL_ARCH to specify the architecture-dependent
path location of the DTB files.

Change-Id: I302f407d987e1b33acb0e47b284a1cb793747691

generate_extra_images: Allow supplying arguments to dtbtool
- Also add a message to indicate when dt.img is generated

Change-Id: I670cc8aa571269d1dc1085e51b063fb890dc05f2
